### PR TITLE
Fixed a load of bugs and restructured program.cs

### DIFF
--- a/ShaellLang.Test/UnitTest1.cs
+++ b/ShaellLang.Test/UnitTest1.cs
@@ -4,53 +4,49 @@ namespace ShaellLang.Test;
 
 public class UnitTest1
 {
-    private ShaellLang shaellLang = new ShaellLang();
-    
     [Fact]
     public void TestOperators()
     {
-        // Act  
-        bool testFailed = shaellLang.Run("../../../OperatorTest.æ", new string[]{"OperatorTest.æ", ""});
-
-        // Assert
-        Assert.False(testFailed);
+        ShaellLang shaellLang = new ShaellLang();
+        shaellLang.LoadStdLib();
+        
+        shaellLang.RunFile("../../../OperatorTest.æ");
     }
     
     [Fact]
     public void TestMetaTables()
     {   
-        // Act  
-        bool testFailed = shaellLang.Run("../../../MetatableTest.æ", new string[]{"MetatableTest.æ", ""});
+        ShaellLang shaellLang = new ShaellLang();
+        shaellLang.LoadStdLib();
 
-        // Assert
-        Assert.False(testFailed);
+        shaellLang.RunFile("../../../MetatableTest.æ");
     }
 
     [Fact]
     public void TestStringInterpolation()
     {
-        // Act
-        bool testFailed = shaellLang.Run("../../../StringInterpolationTest.æ", new string[]{"StringInterpolationTest.æ", ""});
-        
-        // Assert
-        Assert.False(testFailed);
+        ShaellLang shaellLang = new ShaellLang();
+        shaellLang.LoadStdLib();
+
+        shaellLang.RunFile("../../../StringInterpolationTest.æ");
     }
     
     [Fact]
     public void TestScope()
     {
-        // Act
-        bool testFailed = shaellLang.Run("../../../ScopeTest.æ", new string[]{"ScopeTest.æ", ""});
-        
-        // Assert
-        Assert.False(testFailed);
+        ShaellLang shaellLang = new ShaellLang();
+        shaellLang.LoadStdLib();
+
+        shaellLang.RunFile("../../../ScopeTest.æ");
     }
 
     [Fact]
     public void TestTryThrow()
     {
-        bool testFailed = shaellLang.Run("../../../TryThrowTest.æ", new string[]{"TryThrowTest.æ", ""});
-        Assert.False(testFailed);
+        ShaellLang shaellLang = new ShaellLang();
+        shaellLang.LoadStdLib();
+
+        shaellLang.RunFile("../../../TryThrowTest.æ");
     }
     
 }

--- a/ShaellLang/ExecutionVisitor.cs
+++ b/ShaellLang/ExecutionVisitor.cs
@@ -67,7 +67,7 @@ public class ExecutionVisitor : ShaellParserBaseVisitor<IValue>
         return VisitStmts(context.stmts(), false);
     }
 
-    private IValue VisitStmts(ShaellParser.StmtsContext context, bool scoper, bool implicitReturn = false)
+    public IValue VisitStmts(ShaellParser.StmtsContext context, bool scoper, bool implicitReturn = false)
     {
         if (scoper)
             _scopeManager.PushScope(new ScopeContext());
@@ -240,7 +240,7 @@ public class ExecutionVisitor : ShaellParserBaseVisitor<IValue>
 
         var value = lhs as RefValue;
         if (value == null)
-            throw new SyntaxErrorException("Syntax Error: Tried to assign to non ref");
+            throw new SemanticError("Tried to assignt to non ref", context.start, context.stop);
 
         RefValue refLhs = value;
 

--- a/ShaellLang/ShaellException.cs
+++ b/ShaellLang/ShaellException.cs
@@ -10,4 +10,9 @@ public class ShaellException : Exception
     {
         ExceptionValue = exceptionValue;
     }
+
+    public override string ToString()
+    {
+        return $"Uncaught Shaell Exception:\n{ExceptionValue}";
+    }
 }

--- a/ShaellLang/ShaellLang.cs
+++ b/ShaellLang/ShaellLang.cs
@@ -1,56 +1,96 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Antlr4.Runtime;
 
 namespace ShaellLang
 {
-	public class ShaellLang
-	{
-		//Runs the test script and returns whether it failed or not
-		public bool Run(string file, string[] args)
-		{
-			string fileContent = File.ReadAllText(file);
+    public class ShaellLang
+    {
+        private ExecutionVisitor _executioner;
+        private ShaellErrorReporter _errorReporter;
 
-			try
-			{
-				AntlrInputStream inputStream = new AntlrInputStream(fileContent);
-				ShaellLexer shaellLexer = new ShaellLexer(inputStream);
-				CommonTokenStream commonTokenStream = new CommonTokenStream(shaellLexer);
-				ShaellParser shaellParser = new ShaellParser(commonTokenStream);
+        public ShaellLang()
+        {
+            _executioner = new ExecutionVisitor();
+        }
+        
+        public ShaellLang(IEnumerable<string> args)
+        {
+            _executioner = new ExecutionVisitor(args.ToArray());
+        }
 
-				ShaellParser.ProgContext progContext = shaellParser.prog();
-				var executer = new ExecutionVisitor(args[1..]);
-				executer.SetGlobal("print", new NativeFunc(delegate(IEnumerable<IValue> args)
-				{
-					foreach (var value in args)
-					{
-						Console.Write(value.ToSString().Val);
-					}
+        private ShaellParser CreateParser(string code)
+        {
+            _errorReporter = new ShaellErrorReporter();
+            AntlrInputStream inputStream = new AntlrInputStream(code);
+            ShaellLexer shaellLexer = new ShaellLexer(inputStream);
+            
+            _errorReporter.SetErrorListener(shaellLexer);
+            
+            CommonTokenStream commonTokenStream = new CommonTokenStream(shaellLexer);
+            var parser = new ShaellParser(commonTokenStream);
+            
+            _errorReporter.SetErrorListener(parser);
+            if (_errorReporter.HasErrors)
+            {
+                throw new ShaellLangSyntaxException(_errorReporter);
+            }
+            return parser;
+        }
+        
+        public void LoadStdLib()
+        {
+            _executioner.SetGlobal("print", new NativeFunc(StdLib.PrintFunc, 0));
+            _executioner.SetGlobal("cd", new NativeFunc(StdLib.CdFunc, 0));
+            _executioner.SetGlobal("exit", new NativeFunc(StdLib.ExitFunc, 0));
+            _executioner.SetGlobal("debug_break", new NativeFunc(StdLib.DebugBreakFunc, 0));
+            _executioner.SetGlobal("T", TableLib.CreateLib());
+            _executioner.SetGlobal("A", TestLib.CreateLib());
+        }
+        
+        public void SetGlobal(string name, IValue value)
+        {
+            _executioner.SetGlobal(name, value);
+        }
 
-					Console.WriteLine();
+        public IValue RunCode(string code)
+        {
+            var parser = CreateParser(code);
+            //If we just run code, we cant have the args() syntax
+            //Therefore we just parse stmts
+            var stmts = parser.stmts();
+            if (_errorReporter.HasErrors)
+            {
+                throw new ShaellLangSyntaxException(_errorReporter);
+            }
+            return _executioner.VisitStmts(stmts, false, true);
+        }
 
-					return new SNull();
-				}, 0));
+        public IValue RunFile(string path)
+        {
+            var parser = CreateParser(File.ReadAllText(path));
+            var progContext = parser.prog();
+            if (_errorReporter.HasErrors)
+            {
+                throw new ShaellLangSyntaxException(_errorReporter);
+            }
+            return _executioner.Visit(progContext);
+        }
+    }
 
-				executer.SetGlobal("T", TableLib.CreateLib());
+    class ShaellLangSyntaxException : Exception
+    {
+        private ShaellErrorReporter _errorListener;
+        public ShaellLangSyntaxException(ShaellErrorReporter errorListener)
+        {
+            _errorListener = errorListener;
+        }
 
-				executer.SetGlobal("A", TestLib.CreateLib());
-
-				executer.SetGlobal("debug_break", new NativeFunc(delegate(IEnumerable<IValue> args)
-				{
-					Console.WriteLine("Debug break");
-					return new SNull();
-				}, 0));
-				executer.Visit(progContext);
-			}
-			catch (SyntaxErrorException e)
-			{
-				Console.WriteLine(e.Message);
-				return TestLib.testFailed;
-
-			}
-			return TestLib.testFailed;
-		}
-	}
+        public override string ToString()
+        {
+            return _errorListener.ToString();
+        }
+    }
 }


### PR DESCRIPTION
Der var forskellige behavior når shaell kørte tests, interactive mode og script mode. Derfor så fik jeg dem alle til at kører med samme klasse, det aflsørede så 2,234,731,364.25 bugs som jeg derefter aflivede. Så nu virker error handling og syntax errors virker korrekt nu istedet for at trolle.
![bitmoji](https://sdk.bitmoji.com/render/panel/bc65be49-31d3-4cea-8f87-9ecc190e0133-8bd97f06-2f23-448b-ae3a-e66d5540cbf1-v1.png?transparent=1&palette=1&width=246)